### PR TITLE
const enum 사용하지 않기

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -31,7 +31,7 @@ function generateFile(typeMap, fileDesc, parameter) {
             continue;
         }
         const [enumSpec, enumToJson] = enumGenerated;
-        file = file.addEnum(enumSpec).addFunction(enumToJson);
+        file = file.addTypeAlias(enumSpec).addFunction(enumToJson);
     }
     index = 0;
     for (const message of fileDesc.messageType) {
@@ -55,7 +55,8 @@ function generateEnum(enumDesc, sourceInfo, options) {
         return undefined;
     }
     let name = maybeSnakeToCamel(enumDesc.name, options);
-    let spec = ts_poet_1.EnumSpec.create(name).addModifiers(ts_poet_1.Modifier.CONST, ts_poet_1.Modifier.EXPORT);
+    let enumTypeNames = [];
+    let javaDocs = [];
     let toJsonSpec = ts_poet_1.FunctionSpec.create(name + '_fromString')
         .addModifiers(ts_poet_1.Modifier.EXPORT)
         .returns(`${name} | undefined`)
@@ -71,13 +72,20 @@ function generateEnum(enumDesc, sourceInfo, options) {
         const info = sourceInfo.lookup(sourceInfo_1.Fields.enum.value, index++);
         let javaDoc = undefined;
         utils_1.maybeAddComment(info, text => (javaDoc = text));
-        spec = spec.addConstant(valueDesc.name, `"${valueDesc.name}"`, javaDoc != null ? ts_poet_1.CodeBlock.of(javaDoc) : javaDoc);
-        toJsonSpec = toJsonSpec.addCode('case %L:\n', name + '.' + valueDesc.name);
+        enumTypeNames.push(valueDesc.name);
+        if (javaDoc != null) {
+            javaDocs.push(ts_poet_1.CodeBlock.of(`${valueDesc.name} : \n%>` + javaDoc + '%<'));
+        }
+        toJsonSpec = toJsonSpec.addCode('case %S:\n', valueDesc.name);
     }
     toJsonSpec = toJsonSpec
         .addCode('return str\n')
         .addCode('default: return undefined\n')
         .endControlFlow();
+    let spec = ts_poet_1.TypeAliasSpec.create(name, ts_poet_1.TypeNames.unionType(...enumTypeNames));
+    for (const doc of javaDocs) {
+        spec = spec.addJavadocBlock(doc);
+    }
     return [spec, toJsonSpec];
 }
 function generateInterfaceDeclaration(typeMap, messageDesc, sourceInfo, options) {
@@ -188,7 +196,7 @@ function generateInterfaceDeclaration(typeMap, messageDesc, sourceInfo, options)
             }
             const [enumSpec, enumToJson] = enumGenerated;
             namespaceSpec = namespaceSpec
-                .addEnum(enumSpec)
+                .addTypeAlias(enumSpec)
                 .addFunction(enumToJson);
         }
     }

--- a/dist/main.js
+++ b/dist/main.js
@@ -62,7 +62,7 @@ function generateEnum(enumDesc, sourceInfo, options) {
         .returns(`${name} | undefined`)
         .addParameter('str', 'string')
         .beginControlFlow('switch (str)');
-    utils_1.maybeAddComment(sourceInfo, text => (spec = spec.addJavadoc(text)));
+    utils_1.maybeAddComment(sourceInfo, text => (javaDocs.push(ts_poet_1.CodeBlock.of(text + '\n'))));
     let index = 0;
     for (const valueDesc of enumDesc.value) {
         if (((_b = valueDesc.options) === null || _b === void 0 ? void 0 : _b.clientDeprecatedEnumValue) === true) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-proto",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "",
   "main": "build/plugin.js",
   "repository": "github:stephenh/ts-proto",

--- a/sample/sample.proto
+++ b/sample/sample.proto
@@ -30,7 +30,10 @@ message ParentMessage {
     }
 
     enum ChildEnum {
+        // comment for lorem
         CHILD_LOREM = 0;
+        // comment for ipsum
+        // comment2 for ipsum
         CHILD_IPSUM = 1;
         CHILD_DEPRECATED = 2 [(client_deprecated_enum_value) = true];
     }

--- a/sample/sample.proto
+++ b/sample/sample.proto
@@ -29,6 +29,7 @@ message ParentMessage {
         ChildMessage deprecated = 2 [(client_deprecated_field) = true];
     }
 
+    // comment for child enum
     enum ChildEnum {
         // comment for lorem
         CHILD_LOREM = 0;

--- a/sample/sample.ts
+++ b/sample/sample.ts
@@ -33,6 +33,8 @@ export namespace ParentMessage {
   }
 
   /**
+   *  comment for child enum
+   *
    * CHILD_LOREM : 
      *  comment for lorem
    * CHILD_IPSUM : 

--- a/sample/sample.ts
+++ b/sample/sample.ts
@@ -1,15 +1,12 @@
 /* eslint-disable */
 
 
-export const enum SampleEnum {
-  LOREM = "LOREM",
-  IPSUM = "IPSUM",
-}
+type SampleEnum = LOREM | IPSUM;
 
 export function SampleEnum_fromString(str: string): SampleEnum | undefined {
   switch (str) {
-    case SampleEnum.LOREM:
-    case SampleEnum.IPSUM:
+    case "LOREM":
+    case "IPSUM":
     return str
     default: return undefined
   }
@@ -35,15 +32,19 @@ export namespace ParentMessage {
     }
   }
 
-  export const enum ChildEnum {
-    CHILD_LOREM = "CHILD_LOREM",
-    CHILD_IPSUM = "CHILD_IPSUM",
-  }
+  /**
+   * CHILD_LOREM : 
+     *  comment for lorem
+   * CHILD_IPSUM : 
+     *  comment for ipsum
+     *  comment2 for ipsum
+   */
+  type ChildEnum = CHILD_LOREM | CHILD_IPSUM;
 
   export function ChildEnum_fromString(str: string): ChildEnum | undefined {
     switch (str) {
-      case ChildEnum.CHILD_LOREM:
-      case ChildEnum.CHILD_IPSUM:
+      case "CHILD_LOREM":
+      case "CHILD_IPSUM":
       return str
       default: return undefined
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -101,7 +101,7 @@ function generateEnum(enumDesc: EnumDescriptorProto, sourceInfo: SourceInfo, opt
     .returns(`${name} | undefined`)
     .addParameter('str', 'string')
     .beginControlFlow('switch (str)');
-  maybeAddComment(sourceInfo, text => (spec = spec.addJavadoc(text)));
+  maybeAddComment(sourceInfo, text => (javaDocs.push(CodeBlock.of(text + '\n'))));
 
   let index = 0;
   for (const valueDesc of enumDesc.value) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,8 @@ import {
   InterfaceSpec,
   Modifier,
   PropertySpec,
+  TypeAliasSpec,
+  TypeNameOrString,
   TypeNames
 } from './ts-poet';
 import { google } from '../proto-plugin/pbjs';
@@ -67,7 +69,7 @@ export function generateFile(typeMap: TypeMap, fileDesc: FileDescriptorProto, pa
       continue;
     }
     const [enumSpec, enumToJson] = enumGenerated;
-    file = file.addEnum(enumSpec).addFunction(enumToJson)
+    file = file.addTypeAlias(enumSpec).addFunction(enumToJson)
   }
 
   index = 0;
@@ -87,12 +89,13 @@ export function generateFile(typeMap: TypeMap, fileDesc: FileDescriptorProto, pa
   return file;
 }
 
-function generateEnum(enumDesc: EnumDescriptorProto, sourceInfo: SourceInfo, options: Options): [EnumSpec, FunctionSpec] | undefined {
+function generateEnum(enumDesc: EnumDescriptorProto, sourceInfo: SourceInfo, options: Options): [TypeAliasSpec, FunctionSpec] | undefined {
   if (enumDesc.options?.clientDeprecatedEnum === true) {
     return undefined;
   }
   let name = maybeSnakeToCamel(enumDesc.name, options)
-  let spec = EnumSpec.create(name).addModifiers(Modifier.CONST, Modifier.EXPORT);
+  let enumTypeNames: string[] = []
+  let javaDocs: CodeBlock[] = []
   let toJsonSpec = FunctionSpec.create(name+'_fromString')
     .addModifiers(Modifier.EXPORT)
     .returns(`${name} | undefined`)
@@ -109,13 +112,20 @@ function generateEnum(enumDesc: EnumDescriptorProto, sourceInfo: SourceInfo, opt
     const info = sourceInfo.lookup(Fields.enum.value, index++);
     let javaDoc: string | undefined = undefined;
     maybeAddComment(info, text => (javaDoc = text));
-    spec = spec.addConstant(valueDesc.name, `"${valueDesc.name}"`, javaDoc != null ? CodeBlock.of(javaDoc) : javaDoc);
-    toJsonSpec = toJsonSpec.addCode('case %L:\n', name + '.' + valueDesc.name)
+    enumTypeNames.push(valueDesc.name)
+    if (javaDoc != null) {
+      javaDocs.push(CodeBlock.of(`${valueDesc.name} : \n%>` + javaDoc + '%<'))
+    }
+    toJsonSpec = toJsonSpec.addCode('case %S:\n', valueDesc.name)
   }
   toJsonSpec = toJsonSpec
     .addCode('return str\n')
     .addCode('default: return undefined\n')
     .endControlFlow();
+  let spec = TypeAliasSpec.create(name, TypeNames.unionType(...enumTypeNames))
+  for (const doc of javaDocs) {
+    spec = spec.addJavadocBlock(doc)
+  }
   return [spec, toJsonSpec];
 }
 
@@ -241,7 +251,7 @@ function generateInterfaceDeclaration(
       }
       const [enumSpec, enumToJson] = enumGenerated;
       namespaceSpec = namespaceSpec
-        .addEnum(enumSpec)
+        .addTypeAlias(enumSpec)
         .addFunction(enumToJson)
     }
   }


### PR DESCRIPTION
const enum 이 babel 에서 지원을 중단했다고 합니다. https://github.com/babel/babel/issues/8741

지금 생각해보니, fromString 이 필요해졌기 때문에 const enum 을 쓸 필요가 없어졌습니다.
따라서 string literal union type 으로 변경하였습니다.