### PR TITLE
fix: oneof 안 scalar 멤버를 optional로 생성

### DIFF
--- a/dist/types.js
+++ b/dist/types.js
@@ -306,6 +306,7 @@ function toTypeName(typeMap, messageDesc, field, options) {
     }
     if (isWithinOneOf(field)) {
         isOneOf = true;
+        isOptional = true;
     }
     return { type, isOptional, isOneOf };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -343,6 +343,7 @@ export function toTypeName(
 
   if (isWithinOneOf(field)) {
     isOneOf = true;
+    isOptional = true;
   }
 
   return { type, isOptional, isOneOf };


### PR DESCRIPTION
문제: oneof 내부 string/int32/bool 등 원시 타입 필드가 TS interface에서 required(`:`)로 찍혀서, "여러 멤버 중 하나만 채워진다"는 oneof의 의미와 타입이 맞지 않았음. (message/enum 멤버는 이미 optional이었음)

원인: src/types.ts의 toTypeName에서 isMessage/isEnum/proto3Optional 분기는 isOptional을 true로 세팅하지만, isWithinOneOf 분기는 isOneOf만 켜고 isOptional은 false로 둔 채 반환했음.

수정: isWithinOneOf 분기 안에서 isOptional = true 도 함께 세팅. proto3 `optional` 키워드가 만든 synthetic oneof는 이미 위쪽
proto3Optional 분기에서 처리되므로 영향 없음 — 사용자가 선언한 실제
oneof 멤버만 optional이 됨. dist도 함께 재빌드.